### PR TITLE
Need newer version of contentful-management with bugfixes

### DIFF
--- a/contentful_importer.gemspec
+++ b/contentful_importer.gemspec
@@ -19,9 +19,9 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'http', '~> 0.6'
+  spec.add_dependency 'http', '~> 0.8'
   spec.add_dependency 'multi_json', '~> 1'
-  spec.add_dependency 'contentful-management', '~> 0.5.0'
+  spec.add_dependency 'contentful-management', '~> 0.7.0'
   spec.add_dependency 'activesupport','~> 4.1'
   spec.add_dependency 'escort','~> 0.4.0'
   spec.add_dependency 'api_cache', ' ~> 0.3.0'


### PR DESCRIPTION
I'm using contentful-importer for a project and also need contentful-management 0.7.0 installed because of some of the bugfixes available in that version.