### PR TITLE
Fix ZeroDivisionError bug caused by Threads accidentally defaulting to 0

### DIFF
--- a/lib/contentful/importer/command.rb
+++ b/lib/contentful/importer/command.rb
@@ -67,7 +67,7 @@ module Contentful
 				# CLI options can override settings of the same name
 				self.class.options.map { |opt| opt.first.split('=').first.split('-').last }.each do |opt|
 					arg = args.option(opt)
-					arg = arg.to_i if opt == 'threads'
+					arg &&= arg.to_i if opt == 'threads'
 					@settings[opt] = arg if arg
 				end
 


### PR DESCRIPTION
When I ran the command 'contentful-importer --configuration=settings.yml import-content-model' and associated commands without an explicit thread count, I'd get a ZeroDivisionError. This should fix that.